### PR TITLE
Added nyccamp module to handle registration changes.

### DIFF
--- a/sites/all/modules/nyccamp/README.md
+++ b/sites/all/modules/nyccamp/README.md
@@ -1,0 +1,13 @@
+NYC Camp customizations 2015
+
+nyccamp.install
+- Changes the weight of nyccamp module to be one more than the ticket_user_registration so that the form from ticket_user_registration is accessible in the form_alter().
+
+nyccamp.module
+- Removes access to the quantity form element for tickets.
+- Appends the description in Ticket Registrant fieldset to Ticket Registration form (Example description text: "Hello admin@nyccamp.org. Not you? Start over) 
+- Attaches js for registration form tweaks
+
+js/registration.js
+- Hides the Ticket Registrant form
+- Copies the values from the Ticket Registration fieldset form to the Ticket Registrant form on submit.

--- a/sites/all/modules/nyccamp/js/registration.js
+++ b/sites/all/modules/nyccamp/js/registration.js
@@ -1,0 +1,45 @@
+/**
+ * @file
+ * Manage tweaks for registration.
+ */
+
+(function ($) {
+  Drupal.behaviors.nyccampRegistration = {
+    attach: function (context, settings) {
+      // Hide the irrelevant ticket registrant fieldset.
+      $('#edit-ticket-registrant').hide();
+
+      // Get the ids for the registration and ticket fields.
+      registrationFields = {
+        'email': '#edit-ticket-registrant-ticket-user-registrant-email',
+        'fname': '#edit-ticket-registrant-field-profile-first-und-0-value',
+        'lname': '#edit-ticket-registrant-field-profile-last-und-0-value'
+      };
+
+      ticketFields = {
+        'email': '#edit-ticket-registrationnew-0-ticket-user-registration-email0',
+        'fname': '#edit-ticket-registrationnew-0-field-profile-first-und-0-value',
+        'lname': '#edit-ticket-registrationnew-0-field-profile-last-und-0-value'
+      };
+
+      // If the email is set in the registrant field, then it is disabled.
+      // We want to replicate this behavior in the user registrant email field.
+      var disabled = $(registrationFields['email']).attr('disabled');
+
+      if (disabled) {
+        $(ticketFields['email']).val($(registrationFields['email']).val());
+      }
+
+      // On form submit, add the values to the ticket registrant form.
+      $('#ticket-register-form').submit( function (e) {
+        if (!disabled) {
+          $(registrationFields['email']).val($(ticketFields['email']).val());
+        }
+
+        $(registrationFields['fname']).val($(ticketFields['fname']).val());
+        $(registrationFields['lname']).val($(ticketFields['lname']).val());
+      });
+
+    }
+  };
+})(jQuery);

--- a/sites/all/modules/nyccamp/nyccamp.info
+++ b/sites/all/modules/nyccamp/nyccamp.info
@@ -1,0 +1,4 @@
+name = NYC Camp 2015
+description = NYC Camp Customizations
+core = 7.x
+package = NYC Camp

--- a/sites/all/modules/nyccamp/nyccamp.install
+++ b/sites/all/modules/nyccamp/nyccamp.install
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @file
+ * NYC Camp install file.
+ */
+
+function nyccamp_install() {
+  // Get the weight of the ticket_user_registration module
+  $weight = db_select('system', 's')
+    ->fields('s', array('weight'))
+    ->condition('name', 'ticket_user_registration', '=')
+    ->execute()
+    ->fetchField();
+
+  // Set our module to a weight 1 heavier, so ours moves lower in execution order
+  db_update('system')
+    ->fields(array('weight' => $weight + 1))
+    ->condition('name', 'nyccamp', '=')
+    ->execute();
+}

--- a/sites/all/modules/nyccamp/nyccamp.module
+++ b/sites/all/modules/nyccamp/nyccamp.module
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @file
+ * NYC Camp customizations for 2015
+ */
+
+
+/**
+ *  Implements hook_form_FORM_ID_alter().
+ *
+ *  Removes access to the quantity form element for tickets.
+ */
+function nyccamp_form_ticket_field_formatter_view_form_alter(&$form, &$form_state, $form_id) {
+  // The form key for ticket_quantity looks like: TICKET_QUANTITY_PREFIX . $ticket_type->ttid.
+  // Since we don't know the ttid, we have to look for it.
+  $children = element_children($form);
+  foreach ($children as $key) {
+    if (strpos($key, TICKET_QUANTITY_PREFIX) !== FALSE) {
+      $form[$key]['#access'] = FALSE;
+    }
+  }
+}
+
+/**
+ *  Implements hook_form_FORM_ID_alter().
+ *
+ *  Makes the ticket registration form less confusing.
+ */
+function nyccamp_form_ticket_register_form_alter(&$form, &$form_state, $form_id) {
+  // There's no need for separate ticket registrant + ticket type registration forms.
+  $form['ticket_registration:new_0']['#description'] .= '<p>' .
+    $form['ticket_registrant']['#description'] . '</p>';
+
+  $form['#attached']['js'] = array(
+    drupal_get_path('module', 'nyccamp') . '/js/registration.js',
+  );
+}


### PR DESCRIPTION
NYC Camp customizations 2015

nyccamp.install
- Changes the weight of nyccamp module to be one more than the ticket_user_registration so that the form from ticket_user_registration is accessible in the form_alter().

nyccamp.module
- Removes access to the quantity form element for tickets.
- Appends the description in Ticket Registrant fieldset to Ticket Registration form (Example description text: "Hello admin@nyccamp.org. Not you? Start over) 
- Attaches js for registration form tweaks

js/registration.js
- Hides the Ticket Registrant form
- Copies the values from the Ticket Registration fieldset form to the Ticket Registrant form on submit.
